### PR TITLE
Use templateid property for templates

### DIFF
--- a/plugins/modules/zabbix_template.py
+++ b/plugins/modules/zabbix_template.py
@@ -352,7 +352,7 @@ class Template(ZabbixBase):
                 continue
             else:
                 template_id = template_list[0]['templateid']
-                template_ids.append(template_id)
+                template_ids.append({'templateid': template_id})
         return template_ids
 
     def add_template(self, template_name, group_ids, link_template_ids, macros):


### PR DESCRIPTION
Fixes "Error -32500: Application error., No permissions to referred object or it does not exist!" error on Zabbix 5.0.

Currently this module is sending: "templates": ["12345"] which result in the above error on Zabbix 5.0. It worked on version 4.0. I didn't found any documented change in API, but it was already required before to send templateid property according to the documentation: https://www.zabbix.com/documentation/5.0/manual/api/reference/template/create

This commit changes request that it is sending: "templates": [{"templateid": "12345"}] which is correct way according to the documentation.

Thanks.